### PR TITLE
Fix U59 crash: port GameUtil.FloodFillFind to new FloodFill.Find API

### DIFF
--- a/ONITwitchLib/Utils/GridUtil.cs
+++ b/ONITwitchLib/Utils/GridUtil.cs
@@ -114,19 +114,19 @@ public static class GridUtil
 	///     or <see cref="Grid.InvalidCell" /> (-1) if one cannot be found in range.
 	/// </returns>
 	/// <remarks>
-	///     This search is based on <c>GameUtil.FloodFillFind</c>, which does a breadth first search,
+	///     This search is based on <c>FloodFill.Find</c>, which does a breadth first search,
 	///     moving out approximately equally in all directions
 	/// </remarks>
-	/// <seealso cref="GameUtil.FloodFillFind{T}" />
+	/// <seealso cref="FloodFill" />
 	/// <seealso cref="IsCellEmpty" />
 	[PublicAPI]
 	public static int NearestEmptyCell(int baseCell)
 	{
-		var emptyCell = GameUtil.FloodFillFind<object>(
-			(cell, _) => IsCellEmpty(cell) && Grid.AreCellsInSameWorld(cell, baseCell),
-			null,
+		// U59: GameUtil.FloodFillFind was removed and replaced by the FloodFill class.
+		var emptyCell = FloodFill.Find(
+			cell => IsCellEmpty(cell) && Grid.AreCellsInSameWorld(cell, baseCell),
 			baseCell,
-			NearestEmptyCellDepth,
+			new FloodFill.MaxDepth(NearestEmptyCellDepth),
 			false,
 			false
 		);
@@ -150,24 +150,24 @@ public static class GridUtil
 	///     empty, or <see cref="Grid.InvalidCell" /> (-1) if one cannot be found in range.
 	/// </returns>
 	/// <remarks>
-	///     This search is based on <c>GameUtil.FloodFillFind</c>, which does a breadth first search,
+	///     This search is based on <c>FloodFill.Find</c>, which does a breadth first search,
 	///     moving out approximately equally in all directions
 	/// </remarks>
-	/// <seealso cref="GameUtil.FloodFillFind{T}" />
+	/// <seealso cref="FloodFill" />
 	/// <seealso cref="IsCellEmpty" />
 	[PublicAPI]
 	public static int FindCellWithCavityClearance(int baseCell)
 	{
-		var emptyCell = GameUtil.FloodFillFind<object>(
-			static (cell, _) =>
+		// U59: GameUtil.FloodFillFind was removed and replaced by the FloodFill class.
+		var emptyCell = FloodFill.Find(
+			cell =>
 			{
 				var cellEmpty = IsCellEmpty(cell);
 				var neighborsValid = GetNeighborsInBounds(cell).All(IsCellEmpty);
 				return cellEmpty && neighborsValid;
 			},
-			null,
 			baseCell,
-			NearestEmptyCellDepth,
+			new FloodFill.MaxDepth(NearestEmptyCellDepth),
 			false,
 			false
 		);
@@ -190,24 +190,24 @@ public static class GridUtil
 	///     neighbors do not have foundation, or <see cref="Grid.InvalidCell" /> (-1) if one cannot be found in range.
 	/// </returns>
 	/// <remarks>
-	///     This search is based on <c>GameUtil.FloodFillFind</c>, which does a breadth first search,
+	///     This search is based on <c>FloodFill.Find</c>, which does a breadth first search,
 	///     moving out approximately equally in all directions
 	/// </remarks>
-	/// <seealso cref="GameUtil.FloodFillFind{T}" />
+	/// <seealso cref="FloodFill" />
 	/// <seealso cref="IsCellFoundationEmpty" />
 	[PublicAPI]
 	public static int FindCellWithFoundationClearance(int baseCell)
 	{
-		var emptyCell = GameUtil.FloodFillFind<object>(
-			static (cell, _) =>
+		// U59: GameUtil.FloodFillFind was removed and replaced by the FloodFill class.
+		var emptyCell = FloodFill.Find(
+			cell =>
 			{
 				var cellEmpty = IsCellFoundationEmpty(cell);
 				var neighborsValid = GetNeighborsInBounds(cell).All(IsCellFoundationEmpty);
 				return cellEmpty && neighborsValid;
 			},
-			null,
 			baseCell,
-			NearestEmptyCellDepth,
+			new FloodFill.MaxDepth(NearestEmptyCellDepth),
 			false,
 			false
 		);
@@ -334,8 +334,9 @@ public static class GridUtil
 		Orientation orientation = Orientation.Neutral
 	)
 	{
-		var foundCell = GameUtil.FloodFillFind<object>(
-			(testCell, _) =>
+		// U59: GameUtil.FloodFillFind was removed and replaced by the FloodFill class.
+		var foundCell = FloodFill.Find(
+			testCell =>
 			{
 				// check that each cell is not solid
 				if (building.PlacementOffsets.Select(
@@ -353,9 +354,8 @@ public static class GridUtil
 						  building.IsValidBuildLocation(null, testCell, orientation, false, out var _);
 				return ret;
 			},
-			null,
 			cell,
-			1_000,
+			new FloodFill.MaxDepth(1_000),
 			false,
 			false
 		);


### PR DESCRIPTION
U56→U59 removed GameUtil.FloodFillFind(Func<int,T,bool>, T, int, int, bool, bool) and replaced it with the FloodFill class, where the max depth is now a FloodFill.MaxDepth struct and the predicate is Func<int,bool>. All four call sites in GridUtil threw MissingMethodException at runtime, breaking every event that places/floods elements (Ethanol Flood, Spawn Liquid/Gas, Poopsplosion, Pocket Dimension, etc.).
This ports the four calls to FloodFill.Find(...) and updates the stale doc-comment references. No behavioural change — all calls previously passed a null user object and (false, false), preserved here. Tested against build U59-740622 (compiles cleanly and the previously-crashing events now run).